### PR TITLE
Update to work with Node 12.13.1 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ This plugin is using [node-mi-flora](https://github.com/demirhanaydin/node-mi-fl
 (sudo) apt-get install bluetooth bluez libbluetooth-dev libudev-dev
 ```
 
-For more details and descriptions for other platforms see the [Noble documentation](https://github.com/noble/noble#readme).
+For more details and descriptions for other platforms see the [Noble documentation](https://github.com/noble/noble#readme). At the moment [Noble](https://www.npmjs.com/package/noble) does not support [Node 10](https://github.com/noble/node-bluetooth-hci-socket/issues/84). Please use Node 9 if you want to use this plugin, untis the issues with Noble are resolved.
+
 
 #### MAC address
 
@@ -34,6 +35,10 @@ Ensure you know the MAC address of your Xiaomi Flower Care. You can use `hcitool
 ```
 (sudo) npm install -g --unsafe-perm homebridge-mi-flower-care
 ```
+
+## Known Issues
+
+
 
 ## Example Configuration
 


### PR DESCRIPTION
Please update the plugin to work with Node 12.13.1 LTS so it can be used with HOOBS 3.1.1 :-).